### PR TITLE
Made all pay instructions extend PayInstruction

### DIFF
--- a/src/main/java/io/payrun/models/AoePayInstruction.java
+++ b/src/main/java/io/payrun/models/AoePayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "AoePayInstruction")
-public class AoePayInstruction
+public class AoePayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="CaseNumber")
     public String caseNumber;

--- a/src/main/java/io/payrun/models/AoeYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/AoeYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "AoeYtdPayInstruction")
-public class AoeYtdPayInstruction
+public class AoeYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Value")
     public java.lang.Double value = 0d;;

--- a/src/main/java/io/payrun/models/BenefitPayInstruction.java
+++ b/src/main/java/io/payrun/models/BenefitPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "BenefitPayInstruction")
-public class BenefitPayInstruction
+public class BenefitPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Code")
     public String code;

--- a/src/main/java/io/payrun/models/BenefitYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/BenefitYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "BenefitYtdPayInstruction")
-public class BenefitYtdPayInstruction
+public class BenefitYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Code")
     public String code;

--- a/src/main/java/io/payrun/models/NiAdjustmentPayInstruction.java
+++ b/src/main/java/io/payrun/models/NiAdjustmentPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "NiAdjustmentPayInstruction")
-public class NiAdjustmentPayInstruction
+public class NiAdjustmentPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="DirCalculationMethod")
     public DirCalculationMethod dirCalculationMethod = DirCalculationMethod.Off;

--- a/src/main/java/io/payrun/models/NiPayInstruction.java
+++ b/src/main/java/io/payrun/models/NiPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "NiPayInstruction")
-public class NiPayInstruction
+public class NiPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="DirCalculationMethod")
     public DirCalculationMethod dirCalculationMethod = DirCalculationMethod.Off;

--- a/src/main/java/io/payrun/models/NiYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/NiYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "NiYtdPayInstruction")
-public class NiYtdPayInstruction
+public class NiYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Value")
     public java.lang.Double value = 0d;;

--- a/src/main/java/io/payrun/models/P45PayInstruction.java
+++ b/src/main/java/io/payrun/models/P45PayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "P45PayInstruction")
-public class P45PayInstruction
+public class P45PayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="TaxablePay")
     public java.lang.Double taxablePay = 0d;;

--- a/src/main/java/io/payrun/models/PayInstruction.java
+++ b/src/main/java/io/payrun/models/PayInstruction.java
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-@JsonRootName(value = "PayInstruction")
-public class PayInstruction
+public abstract class PayInstruction
 {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/src/main/java/io/payrun/models/PensionPayInstruction.java
+++ b/src/main/java/io/payrun/models/PensionPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "PensionPayInstruction")
-public class PensionPayInstruction
+public class PensionPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Code")
     public String code;

--- a/src/main/java/io/payrun/models/PensionYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/PensionYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "PensionYtdPayInstruction")
-public class PensionYtdPayInstruction
+public class PensionYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="PensionablePay")
     public java.lang.Double pensionablePay = 0d;;

--- a/src/main/java/io/payrun/models/PrimitivePayInstruction.java
+++ b/src/main/java/io/payrun/models/PrimitivePayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "PrimitivePayInstruction")
-public class PrimitivePayInstruction
+public class PrimitivePayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Code")
     public String code;

--- a/src/main/java/io/payrun/models/RatePayInstruction.java
+++ b/src/main/java/io/payrun/models/RatePayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "RatePayInstruction")
-public class RatePayInstruction
+public class RatePayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Code")
     public String code;

--- a/src/main/java/io/payrun/models/SalaryPayInstruction.java
+++ b/src/main/java/io/payrun/models/SalaryPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SalaryPayInstruction")
-public class SalaryPayInstruction
+public class SalaryPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="AnnualSalary")
     public java.lang.Double annualSalary = 0d;;

--- a/src/main/java/io/payrun/models/SapPayInstruction.java
+++ b/src/main/java/io/payrun/models/SapPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SapPayInstruction")
-public class SapPayInstruction
+public class SapPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/SapYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/SapYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SapYtdPayInstruction")
-public class SapYtdPayInstruction
+public class SapYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/ShppPayInstruction.java
+++ b/src/main/java/io/payrun/models/ShppPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "ShppPayInstruction")
-public class ShppPayInstruction
+public class ShppPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/ShppYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/ShppYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "ShppYtdPayInstruction")
-public class ShppYtdPayInstruction
+public class ShppYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/SmpPayInstruction.java
+++ b/src/main/java/io/payrun/models/SmpPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SmpPayInstruction")
-public class SmpPayInstruction
+public class SmpPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/SmpYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/SmpYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SmpYtdPayInstruction")
-public class SmpYtdPayInstruction
+public class SmpYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/SppYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/SppYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SppYtdPayInstruction")
-public class SppYtdPayInstruction
+public class SppYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/SspPayInstruction.java
+++ b/src/main/java/io/payrun/models/SspPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SspPayInstruction")
-public class SspPayInstruction
+public class SspPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/SspYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/SspYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "SspYtdPayInstruction")
-public class SspYtdPayInstruction
+public class SspYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonProperty(value="AbsenceStart")

--- a/src/main/java/io/payrun/models/StudentLoanPayInstruction.java
+++ b/src/main/java/io/payrun/models/StudentLoanPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "StudentLoanPayInstruction")
-public class StudentLoanPayInstruction
+public class StudentLoanPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="StudentLoanCalculationMethod")
     public StudentLoanCalculationMethod studentLoanCalculationMethod = StudentLoanCalculationMethod.Off;

--- a/src/main/java/io/payrun/models/StudentLoanYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/StudentLoanYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "StudentLoanYtdPayInstruction")
-public class StudentLoanYtdPayInstruction
+public class StudentLoanYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Value")
     public java.lang.Double value = 0d;;

--- a/src/main/java/io/payrun/models/TaxPayInstruction.java
+++ b/src/main/java/io/payrun/models/TaxPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "TaxPayInstruction")
-public class TaxPayInstruction
+public class TaxPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="TaxBasis")
     public TaxBasis taxBasis = TaxBasis.Cumulative;

--- a/src/main/java/io/payrun/models/TaxYtdPayInstruction.java
+++ b/src/main/java/io/payrun/models/TaxYtdPayInstruction.java
@@ -5,19 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value = "TaxYtdPayInstruction")
-public class TaxYtdPayInstruction
+public class TaxYtdPayInstruction extends PayInstruction
 {
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="StartDate")
-    public java.util.Date startDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonProperty(value="EndDate")
-    public java.util.Date endDate;
-
-    @JsonProperty(value="Description")
-    public String description;
 
     @JsonProperty(value="Value")
     public java.lang.Double value = 0d;;

--- a/src/test/java/io/payrun/models/RatePayInstructionTest.java
+++ b/src/test/java/io/payrun/models/RatePayInstructionTest.java
@@ -1,0 +1,44 @@
+package io.payrun.models;
+
+import io.payrun.helpers.SerializerHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+
+public class RatePayInstructionTest {
+
+    private SerializerHelper serializerHelper;
+
+    @BeforeEach
+    void setUp() {
+        serializerHelper = new SerializerHelper();
+    }
+
+    @Test
+    public void givenRatePayInstructionInstance_WhenSerialising_ThenExpectedJsonCreated() throws Exception {
+        RatePayInstruction ratePayInstruction1 = new RatePayInstruction();
+        ratePayInstruction1.code = "code";
+        ratePayInstruction1.rate = 12.2;
+        ratePayInstruction1.rateUoM = UomBasicPay.Day;
+        ratePayInstruction1.units = 32.3;
+        ratePayInstruction1.description = "description";
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.MONTH, 0);
+        cal.set(Calendar.YEAR, 2018);
+        ratePayInstruction1.startDate = cal.getTime();
+        cal.set(Calendar.DAY_OF_MONTH, 10);
+        cal.set(Calendar.MONTH, 9);
+        cal.set(Calendar.YEAR, 2018);
+        ratePayInstruction1.endDate = cal.getTime();
+
+        String serializedRatePayInstruction = serializerHelper.toJson(ratePayInstruction1);
+        Assertions.assertEquals(
+                "{\"RatePayInstruction\":{\"StartDate\":\"2018-01-01\",\"EndDate\":\"2018-10-10\",\"Description\":\"description\",\"Code\":\"code\",\"Rate\":12.2,\"RateUoM\":\"Day\",\"Units\":32.3}}",
+                serializedRatePayInstruction);
+    }
+
+}


### PR DESCRIPTION
`PayInstruction` alone is not a valid pay instruction, but it contains data shared by all pay instructions. All pay instructions should have `PayInstruction` as common ancestor